### PR TITLE
perf(stream): shorten GOP to 1s (iperiod = fps) to cut live time-to-f…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,10 @@ Deux services applicatifs + un serveur RTSP, reliés par mediamtx :
 - **mediamtx (service `mediamtx`)** : serveur RTSP local (`rtsp://localhost:8554/camera`).
 
 Le live et HKSV sont du **passthrough H264 matériel** — aucun ré-encodage.
-Le GOP (`iperiod` dans `camera_manager.py`) est à `fps × 2` (keyframe toutes
-les 2 s) : c'est un compromis latence live ↔ fragments HKSV. Ne pas augmenter
-sans raison (ça rallonge le délai d'apparition du live).
+Le GOP (`iperiod` dans `camera_manager.py`) est à `fps × 1` (keyframe toutes
+les 1 s) : compromis latence live ↔ fragments HKSV. Le live `-c:v copy` ne peut
+rien afficher avant de recevoir une keyframe, donc un GOP court réduit le délai
+d'apparition. Ne pas augmenter sans raison (ça rallonge le time-to-first-frame).
 
 ## Commandes
 

--- a/camera/camera_manager.py
+++ b/camera/camera_manager.py
@@ -141,13 +141,14 @@ class CameraManager:
         self._picam2.pre_callback = self._lores_callback
 
         self._pipe_r, self._pipe_w = os.pipe()
-        # iperiod = 2 × fps → a keyframe every 2 s. Live view (-c:v copy) can
-        # only render once it receives a keyframe, so a shorter GOP cuts the
-        # time-to-first-frame in half. HKSV still works: the prebuffer fragments
-        # on each keyframe (movflags frag_keyframe), yielding clean 2 s fMP4
-        # fragments — the declared 4 s fragmentLength is only a hint.
+        # iperiod = fps → a keyframe every 1 s. Live view (-c:v copy) can only
+        # render once it receives a keyframe, so the shortest practical GOP cuts
+        # the time-to-first-frame. HKSV still works: the prebuffer fragments on
+        # each keyframe (movflags frag_keyframe), yielding 1 s fMP4 fragments —
+        # RETAIN_MS=6000 keeps 6 of them, the declared 4 s fragmentLength is a hint.
+        # Cost: ~10-15 % more bitrate (more keyframes) — negligible at 4 Mbps.
         self._encoder = H264Encoder(
-            bitrate=self._bitrate, iperiod=self._fps * 2, profile="high"
+            bitrate=self._bitrate, iperiod=self._fps, profile="high"
         )
 
         self._last_frame_time = time.monotonic()


### PR DESCRIPTION
…irst-frame

Live view uses -c:v copy and cannot render until it receives a keyframe. Halving the GOP from 2s to 1s cuts the worst-case keyframe wait from 2s to 1s. HKSV stays compatible: prebuffer fragments on each keyframe, RETAIN_MS=6000 keeps 6 one-second fragments. Cost ~10-15% more bitrate, negligible at 4 Mbps.

Claude-Session: https://claude.ai/code/session_016PLFwiyRs5n577W1wrs9p3